### PR TITLE
remove draft flag from Python docs

### DIFF
--- a/docs/codemods/python/pixee_python_sandbox-process-creation.md
+++ b/docs/codemods/python/pixee_python_sandbox-process-creation.md
@@ -1,7 +1,6 @@
 ---
 title: Sandbox Process Creation
 sidebar_position: 1
-draft: true
 ---
 
 

--- a/docs/codemods/python/pixee_python_sandbox-url-creation.md
+++ b/docs/codemods/python/pixee_python_sandbox-url-creation.md
@@ -1,7 +1,6 @@
 ---
 title: Sandbox URL Creation
 sidebar_position: 1
-draft: true
 ---
 
 ## pixee:python/sandbox-url-creation 

--- a/docs/codemods/python/pixee_python_secure-random.md
+++ b/docs/codemods/python/pixee_python_secure-random.md
@@ -1,7 +1,6 @@
 ---
 title: Secure Source of Randomness
 sidebar_position: 1
-draft: true
 ---
 
 ## pixee:python/secure-random


### PR DESCRIPTION
[Previous PR](https://github.com/pixee/docs/pull/29) showed the draft flag works. Python docs didn't show up once merged. Removing them should make them show up.