### PR TITLE
Use empty argument for toArray()

### DIFF
--- a/docs/codemods/java/pixee_java_disable_dircontext_deserialization.md
+++ b/docs/codemods/java/pixee_java_disable_dircontext_deserialization.md
@@ -1,5 +1,5 @@
 ---
-title: Hardened LDAP calls against deserialization attacks
+title: Hardened LDAP Calls Against Deserialization Attacks
 sidebar_position: 1
 ---
 

--- a/docs/codemods/java/pixee_java_encode-jsp-scriptlet.md
+++ b/docs/codemods/java/pixee_java_encode-jsp-scriptlet.md
@@ -29,7 +29,7 @@ Our changes introduce an HTML-encoding mechanism that look something like this:
 +Welcome to our site <%= org.owasp.encoder.Encode.forHtml(request.getParameter("name")) %>
 ```
 
-This change encodes HTML control characters that attackers would use to execute code. 
+This codemod encodes HTML control characters that attackers would use to execute code. 
 
 If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
 

--- a/docs/codemods/java/pixee_java_harden-java-deserialization.md
+++ b/docs/codemods/java/pixee_java_harden-java-deserialization.md
@@ -1,5 +1,5 @@
 ---
-title: Harden Java serialization calls
+title: Harden Java Deserialization Calls
 sidebar_position: 1
 ---
 

--- a/docs/codemods/java/pixee_java_move-switch-default-last.md
+++ b/docs/codemods/java/pixee_java_move-switch-default-last.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 |------------|----------------------------|---------------------|
 | Low        | Merge After Cursory Review | No                  |
 
-This change moves the `default` case of `switch` statements to the end to match convention.
+This codemod moves the `default` case of `switch` statements to the end to match convention.
 
 If code is hard to read, it is by definition hard to reason about. This is true not only during review, but also while coding in that area later. Not being able to quickly and effectively reason about code will lead to bugs, including security vulnerabilities.
 

--- a/docs/codemods/java/pixee_java_switch-literal-first.md
+++ b/docs/codemods/java/pixee_java_switch-literal-first.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 |------------|----------------------|---------------------|
 | Low        | Merge Without Review | No                  |
 
-This change defensively switches the order of literals in comparison expressions to ensure that null pointer exceptions are not unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior.
+This codemod defensively switches the order of literals in comparison expressions to ensure that null pointer exceptions are not unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior.
 
 Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.
 

--- a/docs/codemods/java/pixee_java_use-empty-for-toarray.md
+++ b/docs/codemods/java/pixee_java_use-empty-for-toarray.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 |------------|----------------------|---------------------|
 | Low        | Merge Without Review | No                  |
 
-This change updates new array creation with [https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html#toArray-T:A-](Collection#toArray(T[])) to use an empty array argument, which is better for performance.
+This codemod updates new array creation with [Collection#toArray(T[])](https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html#toArray-T:A-) to use an empty array argument, which is better for performance.
 
 The point of the argument is to it an array to hold the objects and be returned, according to the documentation:
 


### PR DESCRIPTION
Docs for a new codemod. Also updated the casing in titles to be uniformly Upper Case and made the opening statements more uniform as well.