### PR TITLE
Logo should link to pixee.ai

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -71,6 +71,7 @@ const config = {
         logo: {
           alt: 'Pixee',
           src: 'img/logo.png',
+          href: 'https://pixee.ai',
         },
         items: [
           {


### PR DESCRIPTION
## Summary
* Previously linked back to docs site, but we want it to link to pixee.ai
<img width="315" alt="image" src="https://github.com/pixee/docs/assets/2458487/8aff66e1-ce73-4da9-827d-a18a0c5a2459">
