### PR TITLE
Added missing codemods for Java

### DIFF
--- a/docs/codemods/java/codeql_java_database-resource-leak.md
+++ b/docs/codemods/java/codeql_java_database-resource-leak.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## codeql:java/database-resource-leak 
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
-| Medium     | Merge Without Review | Yes (CodeQL)        |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | Yes (CodeQL)           |
 
 This codemod adds [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) to JDBC code that is missing `close()` calls. Without explicit closing, these resources will be "leaked", and won't be re-claimed until garbage collection, leaving connections in an open state. In situations where these resources are leaked rapidly (either through malicious repetitive action or unusually spiky usage),  connection pool or file handle exhaustion will occur. These types of failures tend to be catastrophic, resulting in downtime and many times affect downstream applications.
 

--- a/docs/codemods/java/codeql_java_input-resource-leak.md
+++ b/docs/codemods/java/codeql_java_input-resource-leak.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## codeql:java/input-resource-leak
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
-| Medium     | Merge Without Review | Yes (CodeQL)        |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | Yes (CodeQL)           |
 
 This codemod adds [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) to a subclass of `Reader` or `InputStream` without `close()` calls. Without explicit closing, these resources will be "leaked", and won't be re-claimed until garbage collection.  In situations where these resources are leaked rapidly (either through malicious repetitive action or unusually spiky usage), connection pool or file handle exhaustion will occur. These types of failures tend to be catastrophic, resulting in downtime and many times affect downstream applications.
 

--- a/docs/codemods/java/codeql_java_insecure-cookie.md
+++ b/docs/codemods/java/codeql_java_insecure-cookie.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## codeql:java/insecure-cookie 
 
-| Importance | Review Guidance           | Requires SARIF Tool |
-|------------|---------------------------|---------------------|
- | Low        | Merge After Investigation | Yes (CodeQL)        |
+| Importance | Review Guidance           | Requires Scanning Tool |
+|------------|---------------------------|------------------------|
+ | Low        | Merge After Investigation | Yes (CodeQL)           |
 
 This codemod marks new HTTP cookies with the ["secure" flag](https://owasp.org/www-community/controls/SecureCookieAttribute). This flag, despite its ambitious name, only provides one type of protection: confidentiality. Cookies with this flag are guaranteed by the browser never to be sent over a cleartext channel ("http://") and only sent over secure channels ("https://").
 

--- a/docs/codemods/java/codeql_java_jexl-expression-injection.md
+++ b/docs/codemods/java/codeql_java_jexl-expression-injection.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## codeql:java/jexl-expression-injection 
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium     | Merge After Cursory Review | Yes (CodeQL)        |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Medium     | Merge After Cursory Review | Yes (CodeQL)           |
 
 This codemod adds [a sandbox](https://commons.apache.org/proper/commons-jexl/apidocs/org/apache/commons/jexl3/introspection/JexlSandbox.html) to JEXL expression evaluation. This sandbox prevents access to many types that don't appear in typical usage, but are very common in exploits. 
 

--- a/docs/codemods/java/codeql_java_jwt-signature-check.md
+++ b/docs/codemods/java/codeql_java_jwt-signature-check.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## codeql:java/jwt-signature-check 
 
-| Importance | Review Guidance           | Requires SARIF Tool |
-|------------|---------------------------|---------------------|
- | Medium     | Merge After Investigation | Yes (CodeQL)        |
+| Importance | Review Guidance           | Requires Scanning Tool |
+|------------|---------------------------|------------------------|
+ | Medium     | Merge After Investigation | Yes (CodeQL)           |
 
 This codemod switches Json Web Token (JWT) parsing APIs to versions that perform signature validation.
 

--- a/docs/codemods/java/codeql_java_maven-non-https-url.md
+++ b/docs/codemods/java/codeql_java_maven-non-https-url.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## codeql:java/maven-non-https-url 
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium     | Merge After Cursory Review | Yes (CodeQL)        |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Medium     | Merge After Cursory Review | Yes (CodeQL)           |
 
 This codemod replaces any HTTP URLs found in `<repository>` definitions with HTTPS URLs. Without this change, Maven will make requests to either publish or retrieve artifacts over a plaintext channel. 
 

--- a/docs/codemods/java/codeql_java_output-resource-leak.md
+++ b/docs/codemods/java/codeql_java_output-resource-leak.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## codeql:java/output-resource-leak
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
-| Medium     | Merge Without Review | Yes (CodeQL)        |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | Yes (CodeQL)           |
 
 This codemod adds [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) to a subclass of `Writer` or `OutputStream` without `close()` calls. Without explicit closing, these resources will be "leaked", and won't be re-claimed until garbage collection.  In situations where these resources are leaked rapidly (either through malicious repetitive action or unusually spiky usage), connection pool or file handle exhaustion will occur. These types of failures tend to be catastrophic, resulting in downtime and many times affect downstream applications.
 

--- a/docs/codemods/java/codeql_java_stack-trace-exposure.md
+++ b/docs/codemods/java/codeql_java_stack-trace-exposure.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## codeql:java/stack-trace-exposure 
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | Medium     | Merge Without Review | Yes (CodeQL)        |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | Medium     | Merge Without Review | Yes (CodeQL)           |
 
 This codemod prevents stack trace information from reaching the HTTP response, which could leak code internals to an attacker and aid in further profiling and attacks.
 

--- a/docs/codemods/java/pixee_java_add-clarifying-braces.md
+++ b/docs/codemods/java/pixee_java_add-clarifying-braces.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/add-clarifying-braces
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| High       | Merge After Cursory Review | No                     |
 
 This codemod adds clarifying braces to misleading code blocks that look like they may be executing unintended code.
 

--- a/docs/codemods/java/pixee_java_disable_dircontext_deserialization.md
+++ b/docs/codemods/java/pixee_java_disable_dircontext_deserialization.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/disable-dircontext-deserialization 
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | High       | Merge Without Review | No                     |
 
 This codemod patches the LDAP interaction code to harden against a remote code execution vulnerability.
 

--- a/docs/codemods/java/pixee_java_encode-jsp-scriptlet.md
+++ b/docs/codemods/java/pixee_java_encode-jsp-scriptlet.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/encode-jsp-scriptlet
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
- | High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+ | High       | Merge After Cursory Review | No                     |
 
 
 This codemod encodes certain JSP scriptlets to fix what appear to be trivially exploitable [Reflected Cross-Site Scripting (XSS)](https://portswigger.net/web-security/cross-site-scripting) vulnerabilities in JSP files. XSS is a vulnerability that is tricky to understand initially, but easy to exploit.

--- a/docs/codemods/java/pixee_java_fix-verb-tampering.md
+++ b/docs/codemods/java/pixee_java_fix-verb-tampering.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/fix-verb-tampering
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | High       | Merge Without Review | No                     |
 
 The `web.xml` specification offers a way to protect certain parts of your URL space. Unfortunately, it doesn't work the way people think it does, developers who are trying to enhance their security often end up accidentally exposing those parts they were trying to protect.
 

--- a/docs/codemods/java/pixee_java_harden-java-deserialization.md
+++ b/docs/codemods/java/pixee_java_harden-java-deserialization.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/harden-java-deserialization 
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | High       | Merge Without Review | No                     |
 
 This codemod hardens Java deserialization operations against attack. Even a simple operation like an object deserialization is unfortunately a real opportunity to yield control of your system to an attacker. In fact, without specific protections, any object deserialization call can lead to arbitrary code execution. The JavaDoc [now even says](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/ObjectInputFilter.html):
 

--- a/docs/codemods/java/pixee_java_harden-process-creation.md
+++ b/docs/codemods/java/pixee_java_harden-process-creation.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 
 ## pixee:java/harden-process-creation
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | High       | Merge Without Review | No                     |
 
 This codemod hardens all instances of [Runtime#exec()](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Runtime.html) to offer protection against attack.
 

--- a/docs/codemods/java/pixee_java_harden-xmldecoder-stream.md
+++ b/docs/codemods/java/pixee_java_harden-xmldecoder-stream.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 
 ## pixee:java/harden-xmldecoder-stream
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | High       | Merge Without Review | No                     |
 
 This codemod hardens usage of Java's [`java.beans.XMLDecoder`](https://docs.oracle.com/en/java/javase/17/docs/api/java.desktop/java/beans/XMLDecoder.html) APIs to prevent remote code execution attacks.
 

--- a/docs/codemods/java/pixee_java_harden-xmlinputfactory.md
+++ b/docs/codemods/java/pixee_java_harden-xmlinputfactory.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 
 ## pixee:java/harden-xmlinputfactory
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | High       | Merge Without Review | No                     |
 
 This codemod updates all instances of [XMLInputFactory](https://docs.oracle.com/javase/8/docs/api/javax/xml/stream/XMLInputFactory.html) to prevent them from resolving external entities, which can protect you from arbitrary code execution, sensitive data exfiltration, and an ever-growing list of other abuses attackers have discovered.
 

--- a/docs/codemods/java/pixee_java_harden-xstream.md
+++ b/docs/codemods/java/pixee_java_harden-xstream.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 
 ## pixee:java/harden-xstream
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | High       | Merge Without Review | No                     |
 
 This codemod hardens usage of the `XStream` library to prevent remote code execution attacks.
 

--- a/docs/codemods/java/pixee_java_harden-zip-entry-paths.md
+++ b/docs/codemods/java/pixee_java_harden-zip-entry-paths.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 
 ## pixee:java/harden-zip-entry-paths
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | High       | Merge Without Review | No                     |
 
 This codemod hardens instances of [ZipInputStream](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/zip/ZipInputStream.html) to protect against malicious entries that attempt to escape their "file root" and overwrite other files on the running filesystem.
 

--- a/docs/codemods/java/pixee_java_limit-readline.md
+++ b/docs/codemods/java/pixee_java_limit-readline.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/limit-readline
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
- | Medium     | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+ | Medium     | Merge After Cursory Review | No                     |
 
 This codemod hardens all [`BufferedReader#readLine()`](https://docs.oracle.com/javase/8/docs/api/java/io/BufferedReader.html#readLine--) calls against attack.
 

--- a/docs/codemods/java/pixee_java_make-prng-seed-unpredictable.md
+++ b/docs/codemods/java/pixee_java_make-prng-seed-unpredictable.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/make-prng-seed-unpredictable
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | Low        | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | Low        | Merge Without Review | No                     |
 
 This codemod replaces all the constant seeds passed to `Random#setSeed(long)` with a pseudo-random value, which will make it considerably more secure.
 

--- a/docs/codemods/java/pixee_java_move-switch-default-last.md
+++ b/docs/codemods/java/pixee_java_move-switch-default-last.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/move-switch-default-last
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Low        | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Low        | Merge After Cursory Review | No                     |
 
 This codemod moves the `default` case of `switch` statements to the end to match convention.
 

--- a/docs/codemods/java/pixee_java_prevent-filewriter-leak-with-nio.md
+++ b/docs/codemods/java/pixee_java_prevent-filewriter-leak-with-nio.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/prevent-filewriter-leak-with-nio
 
-| Importance    | Review Guidance            | Requires SARIF Tool |
-|---------------|----------------------------|---------------------|
-| Medium        | Merge Without Review       | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | No                     |
 
 This codemod prevents a file descriptor leak and modernizes the file writing API pattern.
 

--- a/docs/codemods/java/pixee_java_sandbox-url-creation.md
+++ b/docs/codemods/java/pixee_java_sandbox-url-creation.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/sandbox-url-creation 
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
- | High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+ | High       | Merge After Cursory Review | No                     |
 
 This codemod sandboxes the creation of [`java.net.URL`](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/URL.html) objects so they will be more resistant to Server-Side Request Forgery (SSRF) attacks.
 

--- a/docs/codemods/java/pixee_java_sanitize-apache-multipart-filename.md
+++ b/docs/codemods/java/pixee_java_sanitize-apache-multipart-filename.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/sanitize-apache-multipart-filename 
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
- | High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+ | High       | Merge After Cursory Review | No                     |
 
 This codemod hardens usage of Apache Common's popular multipart request and [file uploading library](https://commons.apache.org/proper/commons-fileupload/) to prevent file overwrite attacks.
 

--- a/docs/codemods/java/pixee_java_sanitize-spring-multipart-filename.md
+++ b/docs/codemods/java/pixee_java_sanitize-spring-multipart-filename.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/sanitize-spring-multipart-filename 
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
- | High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+ | High       | Merge After Cursory Review | No                     |
 
 This codemod hardens usage of the [Spring Web](https://github.com/spring-projects/spring-framework) multipart request and file uploading feature to prevent file overwrite attacks.
 

--- a/docs/codemods/java/pixee_java_secure-random.md
+++ b/docs/codemods/java/pixee_java_secure-random.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/secure-random
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | High       | Merge Without Review | No                     |
 
 This codemod replaces all new instances of `java.util.Random` with the marginally slower, but much more secure `java.security.SecureRandom`.
 

--- a/docs/codemods/java/pixee_java_sql-parameterizer.md
+++ b/docs/codemods/java/pixee_java_sql-parameterizer.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/sql-parameterizer
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
- | High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+ | High       | Merge Without Review | No                     |
 
 This codemod refactors SQL statements to be parameterized, rather than built by hand.
 

--- a/docs/codemods/java/pixee_java_strip-http-header-newlines.md
+++ b/docs/codemods/java/pixee_java_strip-http-header-newlines.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/strip-http-header-newlines
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
-| Medium     | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | No                     |
 
 This codemod ensures that HTTP response header values can't contain newline characters, which could disrupt communication with proxies and possibly leave you vulnerable to protocol-based attacks.
 

--- a/docs/codemods/java/pixee_java_switch-literal-first.md
+++ b/docs/codemods/java/pixee_java_switch-literal-first.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/switch-literal-first
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
-| Low        | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | No                     |
 
 This codemod defensively switches the order of literals in comparison expressions to ensure that null pointer exceptions are not unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior.
 

--- a/docs/codemods/java/pixee_java_upgrade-sslcontext-tls.md
+++ b/docs/codemods/java/pixee_java_upgrade-sslcontext-tls.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/upgrade-sslcontext-tls
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
- | High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+ | High       | Merge After Cursory Review | No                     |
 
 This codemod ensures that `SSLSocket#setEnabledProtocols()` uses a safe version of Transport Layer Security (TLS), which is necessary for safe SSL connections.
 

--- a/docs/codemods/java/pixee_java_upgrade-sslengine-tls.md
+++ b/docs/codemods/java/pixee_java_upgrade-sslengine-tls.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/upgrade-sslengine-tls
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| High       | Merge After Cursory Review | No                     |
 
 This codemod ensures that `SSLEngine#setEnabledProtocols()` retrieves a safe version of Transport Layer Security (TLS), which is necessary for safe SSL connections.
 

--- a/docs/codemods/java/pixee_java_upgrade-sslparameters-tls.md
+++ b/docs/codemods/java/pixee_java_upgrade-sslparameters-tls.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/upgrade-sslparameters-tls
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| High       | Merge After Cursory Review | No                     |
 
 This codemod ensures that `SSLParameters#setProtocols()` uses a safe version of Transport Layer Security (TLS), which is necessary for safe SSL connections.
 

--- a/docs/codemods/java/pixee_java_upgrade-sslsocket-tls.md
+++ b/docs/codemods/java/pixee_java_upgrade-sslsocket-tls.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/upgrade-sslsocket-tls
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| High       | Merge After Cursory Review | No                     |
 
 This codemod ensures that `SSLSocket#setEnabledProtocols()` uses a safe version of Transport Layer Security (TLS), which is necessary for safe SSL connections.
 

--- a/docs/codemods/java/pixee_java_upgrade-tempfile-to-nio.md
+++ b/docs/codemods/java/pixee_java_upgrade-tempfile-to-nio.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/upgrade-tempfile-to-nio
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
-| Medium     | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | No                     |
 
 This codemod replaces the usage of [`java.io.File#createTempFile`](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/io/File.html#createTempFile(java.lang.String,java.lang.String)) with [`java.nio.file.Files#createTempFile`](https://docs.oracle.com/en/java/javase/20/docs/api/java.base/java/nio/file/Files.html#createTempFile(java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute...)) which has more secure attributes.
 

--- a/docs/codemods/java/pixee_java_use-empty-for-toarray.md
+++ b/docs/codemods/java/pixee_java_use-empty-for-toarray.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/use-empty-for-toarray
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
-| Low        | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | No                     |
 
 This codemod updates new array creation with [Collection#toArray(T[])](https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html#toArray-T:A-) to use an empty array argument, which is better for performance.
 

--- a/docs/codemods/java/pixee_java_validate-jakarta-forward-path.md
+++ b/docs/codemods/java/pixee_java_validate-jakarta-forward-path.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:java/validate-jakarta-forward-path
 
-| Importance | Review Guidance      | Requires SARIF Tool |
-|------------|----------------------|---------------------|
-| High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| High       | Merge Without Review | No                     |
 
 This codemod hardens all [`ServletRequest#getRequestDispatcher(String)`](https://docs.oracle.com/javaee/7/api/javax/servlet/ServletRequest.html#getRequestDispatcher-java.lang.String-) calls against attack.
 

--- a/docs/codemods/java/semgrep_java_java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission.md
+++ b/docs/codemods/java/semgrep_java_java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission.md
@@ -1,0 +1,47 @@
+---
+title: "Semgrep: Overly Permissive File Permission"
+sidebar_position: 1
+---
+
+## semgrep:java/java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission
+
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Medium     | Merge After Cursory Review | Yes (Semgrep)          |
+
+This codemod removes excessive privilege from a file that appears to be overly permissive. Files can be granted privileges to the file's owner, the file owner's group, or "others" -- meaning anyone else. It is hard to imagine the need for a file to be readable, writable or executable by anyone other than the file's owner or the file owner's group in modern software development.
+
+If a file is readable by "others", it could be read by a malicious system user to retrieve sensitive information or useful implementation details. If the file is writable by "others", the application could be tricked into performing actions on data provide by malicious users. Allowing execution of a file by "others" could allow malicious users to run arbitrary code on the server.
+
+Our changes look something like this:
+
+```diff
+  Set<PosixFilePermission> startupPermissions = new HashSet<PosixFilePermission>();
+- startupPermissions.add(PosixFilePermission.OTHERS_WRITE);
++ startupPermissions.add(PosixFilePermission.GROUP_WRITE);
+  Files.setPosixFilePermissions(startupScript, startupPermissions);
+  
+- Set<PosixFilePermission> shutdownPermissions = PosixFilePermissions.fromString("rwxrwxrwx");
++ Set<PosixFilePermission> shutdownPermissions = PosixFilePermissions.fromString("rwxrwx---");
+  Files.setPosixFilePermissions(shutdownScript, shutdownPermissions);
+```
+
+Note: It's worth considering whether you could use a more restrictive permission than `GROUP_WRITE` here. For example, if the file is owned by the same user that's running the application, you could use `OWNER_WRITE` instead.
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge After Review?
+
+Although there is very little reason to limiting the file permissions as stated would have any effect, it conceivable that the weak permissions are incidentally taken advantage of during pre-production development practices or through file aggregation tools (e.g., Splunk.)  
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://find-sec-bugs.github.io/bugs.htm#OVERLY_PERMISSIVE_FILE_PERMISSION](https://find-sec-bugs.github.io/bugs.htm#OVERLY_PERMISSIVE_FILE_PERMISSION)
+* [https://registry.semgrep.dev/rule/java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission](https://registry.semgrep.dev/rule/java.lang.security.audit.overly-permissive-file-permission.overly-permissive-file-permission)
+* [https://cwe.mitre.org/data/definitions/732.html](https://cwe.mitre.org/data/definitions/732.html)

--- a/docs/codemods/java/sonar_java_add-missing-override-s1161.md
+++ b/docs/codemods/java/sonar_java_add-missing-override-s1161.md
@@ -1,0 +1,45 @@
+---
+title: "Sonar: Add Missing @Override Annotation"
+sidebar_position: 1
+---
+
+## sonar:java/add-missing-override-s1161
+
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | Yes (Sonar)            |
+
+This codemod adds missing `@Override` annotations to known subclass methods. Documenting inheritance will help readers and static analysis tools understand the code better, spot bugs easier, and in general lead to more efficient and effective review.
+
+Our changes look something like this:
+
+```diff
+  interface AcmeParent {
+     void doThing();
+  } 
+
+  class AcmeChild implements AcmeParent {
+
++   @Override
+    void doThing() {
+      thing();
+    }
+    
+  }
+```
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge Without Review?
+
+There is no functional difference after the change, but the source code will be easier to understand.
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://rules.sonarsource.com/java/RSPEC-1161/](https://rules.sonarsource.com/java/RSPEC-1161/)

--- a/docs/codemods/java/sonar_java_avoid-implicit-public-constructor-s1118.md
+++ b/docs/codemods/java/sonar_java_avoid-implicit-public-constructor-s1118.md
@@ -1,0 +1,37 @@
+---
+title: "Sonar: Prevent utility class from instantiation"
+sidebar_position: 1
+---
+
+## sonar:java/avoid-implicit-public-constructor-s1118
+
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Low        | Merge After Cursory Review | Yes (Sonar)            |
+
+This codemod adds private constructors to utility classes. Utility classes are only meant to be accessed statically. Since they're not meant to be instantiated, we can use the Java's code visibility protections to hide the constructor and prevent unintended or malicious access.
+
+Our changes look something like this:
+
+```diff
+   public class Utils {
++    private Utils() {}
+     ...
+```
+
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge After Cursory Review?
+
+This change depends completely on Sonar's accuracy about in identifying types that are meant to only offer static utilities. Our testing shows this generally works as expected, but correctness can't be guaranteed in all situations.
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://rules.sonarsource.com/java/RSPEC-1118/](https://rules.sonarsource.com/java/RSPEC-1118/)

--- a/docs/codemods/java/sonar_java_harden-string-parse-to-primitives-s2130.md
+++ b/docs/codemods/java/sonar_java_harden-string-parse-to-primitives-s2130.md
@@ -1,0 +1,46 @@
+---
+title: "Sonar: Implemented parsing usage when converting Strings to primitives"
+sidebar_position: 1
+---
+
+## sonar:java/harden-string-parse-to-primitives-s2130
+
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | Yes (Sonar)            |
+
+This codemod updates `String`-to-number conversions by leveraging the intended parse methods.
+
+This change makes developer intent clearer, and sometimes with a more concise expression.
+
+Our changes look like this:
+
+```diff
+    String number = "7.1";
+
+-   int integerNum = Integer.valueOf(number);
++   int integerNum = Integer.parseInt(number);
+
+-   float floatNumVal = Float.valueOf(number).floatValue();
++   float floatNumVal = Float.parseFloat(number);
+
+-   int integerNumber = new Integer(number);
++   int integerNumber = Integer.parseInt(number);
+```
+
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge Without Review?
+
+There is no functional difference after the change, but the source code will be easier to understand.
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://rules.sonarsource.com/java/RSPEC-2130/](https://rules.sonarsource.com/java/RSPEC-2130/)

--- a/docs/codemods/java/sonar_java_remove-redundant-static-s2786.md
+++ b/docs/codemods/java/sonar_java_remove-redundant-static-s2786.md
@@ -1,0 +1,42 @@
+---
+title: "Sonar: Remove redundant static keywords on nested enum"
+sidebar_position: 1
+---
+
+## sonar:java/remove-redundant-static-s2786
+
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | Yes (Sonar)            |
+
+This codemod removes redundant (and possibly misleading) `static` keywords on `enum` types defined within classes. All `enum` types that are nested within another type are automatically `static`, and so listing the flag this clutters the code, and may cause confusion when reasoning about it.
+
+Our changes look something like this:
+
+```diff
+  @RestController
+  final class CheckStatusController {
+
+-   static enum ResponseType {  
++   enum ResponseType {
+      SUCCESS,
+      FAILURE,
+      ERROR
+    }
+```
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge Without Review?
+
+There are no functional changes after this change, but the code will be easier to understand.
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://sonarsource.github.io/rspec/#/rspec/S2786/java](https://sonarsource.github.io/rspec/#/rspec/S2786/java)

--- a/docs/codemods/java/sonar_java_remove-redundant-variable-creation-s1488.md
+++ b/docs/codemods/java/sonar_java_remove-redundant-variable-creation-s1488.md
@@ -1,0 +1,46 @@
+---
+title: "Sonar: Remove redundant variable creation expression when it is only returned/thrown"
+sidebar_position: 1
+---
+
+## sonar:java/remove-redundant-variable-creation-s1488
+
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | Yes (Sonar)            |
+
+This codemod removes intermediate variables who are only created to be thrown or returned in the next statement. This makes the code more readable, which makes reviewing the code for issues easier.
+
+Our changes look something like this:
+
+```diff
+    public LocaleResolver localeResolver() { 
+-       SessionLocaleResolver localeResolver = new SessionLocaleResolver();
+-       return localeResolver;
++       return new SessionLocaleResolver();
+    }
+```
+
+```diff
+    public void process() { 
+-       Exception ex = new Exception();
+-       throw ex;
++       throw new Exception();
+    }
+```
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge Without Review?
+
+There are no functional changes after this change, but the code will be easier to understand.
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://rules.sonarsource.com/java/RSPEC-1488/](https://rules.sonarsource.com/java/RSPEC-1488/)

--- a/docs/codemods/java/sonar_java_remove-unused-local-variable-s1481.md
+++ b/docs/codemods/java/sonar_java_remove-unused-local-variable-s1481.md
@@ -1,0 +1,39 @@
+---
+title: "Sonar: Remove unused local variable"
+sidebar_position: 1
+---
+
+## sonar:java/remove-unused-local-variable-s1481
+
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Low        | Merge After Cursory Review | Yes (Sonar)            |
+
+This codemod removes unused variables. Unused variables make the code harder to read, which will lead to confusion and bugs. We only remove variables that have no state-changing effects.
+
+Our changes look something like this:
+
+```diff
+     catch (final UnsolvedSymbolException e) {
+-      String errorMessage = "An unexpected exception happened";
+       LOG.error("Problem resolving type of : {}", expr, e);
+       return false;
+     }
+```
+
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge After Cursory Review?
+
+There should be no functional changes after this change as we double check to ensure that the variables . However, we think it may be valuable for a developer to see the change being made and see if it alters their understanding of the code, and if the deletion of the unused variable makes obvious the appearance of any functional bugs. 
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://rules.sonarsource.com/java/RSPEC-1481/](https://rules.sonarsource.com/java/RSPEC-1481/)

--- a/docs/codemods/java/sonar_java_remove-useless-parentheses-s1110.md
+++ b/docs/codemods/java/sonar_java_remove-useless-parentheses-s1110.md
@@ -1,0 +1,37 @@
+---
+title: "Sonar: Remove useless parentheses"
+sidebar_position: 1
+---
+
+## sonar:java/remove-useless-parentheses-s1110
+
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | Yes (Sonar)            |
+
+This codemod removes redundant parentheses. These extra parentheses make it harder to understand the code.
+
+Our changes look something like this:
+
+```diff
+
+-     int leftOver = (int) (((bitCount >>> 3)) & 0x3f);
++     int leftOver = (int) ((bitCount >>> 3) & 0x3f);
+
+```
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge Without Review?
+
+There should be no functional changes after this change, but the code should be easier to read. 
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://rules.sonarsource.com/java/RSPEC-1110/](https://rules.sonarsource.com/java/RSPEC-1110/)

--- a/docs/codemods/java/sonar_java_replace-stream-collectors-to-list-s6204.md
+++ b/docs/codemods/java/sonar_java_replace-stream-collectors-to-list-s6204.md
@@ -1,0 +1,35 @@
+---
+title: "Sonar: Simplify Stream#collect(Collectors#toList()) to Stream#toList()"
+sidebar_position: 1
+---
+
+## sonar:java/replace-stream-collectors-to-list-s6204
+
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | Yes (Sonar)            |
+
+This change modernizes a stream's `List` creation to be driven from the simple, and more readable [`Stream#toList()`](https://docs.oracle.com/javase/16/docs/api/java.base/java/util/stream/Collectors.html#toList()) method.
+
+Our changes look something like this:
+
+```diff
+- List<Integer> numbers = someStream.collect(Collectors.toList());
++ List<Integer> numbers = someStream.toList();
+```
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge Without Review?
+
+There should be no functional changes after this change, but the code should be easier to read. 
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://rules.sonarsource.com/java/RSPEC-6204/](https://rules.sonarsource.com/java/RSPEC-6204/)

--- a/docs/codemods/java/sonar_java_simplify-rest-controller-annotations-s6833.md
+++ b/docs/codemods/java/sonar_java_simplify-rest-controller-annotations-s6833.md
@@ -1,0 +1,44 @@
+---
+title: "Sonar: Migrate @Controller/@ResponseBody to @RestController"
+sidebar_position: 1
+---
+
+## sonar:java/simplify-rest-controller-annotations-s6833
+
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | Yes (Sonar)            |
+
+This codemod makes it harder for developers to make a mistake when writing REST controllers in Spring. By marking the top level type with `@RestController`, it is now assumed that all the methods within it will return a Java object representing the response body. Thus, there is no need to specify, for each method, the `@ResponseBody` annotation.
+
+Our changes look something like this:
+
+```diff
+-   import org.springframework.stereotype.Controller;
+-   import org.springframework.web.bind.annotation.ResponseBody;
++   import org.springframework.web.bind.annotation.RestController;
+-   @Controller
++   @RestController
+    public class AccountController {
+      ...
+-     @ResponseBody
+      public AccountDetails viewAccount() {
+        ...
+```
+
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge Without Review?
+
+There are no functional changes after this change, but the code will be easier to understand.
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://rules.sonarsource.com/java/RSPEC-6833/](https://rules.sonarsource.com/java/RSPEC-6833/)

--- a/docs/codemods/java/sonar_java_substitute-replaceAll-s5361.md
+++ b/docs/codemods/java/sonar_java_substitute-replaceAll-s5361.md
@@ -1,0 +1,39 @@
+---
+title: "Sonar: Fixed inefficient usage of String#replaceAll()"
+sidebar_position: 1
+---
+
+## sonar:java/substitute-replaceAll-s5361
+
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Medium     | Merge After Cursory Review | Yes (Sonar)            |
+
+This codemod replaces `String#replaceAll()` with `String#replace()` to enhance performance and avoid confusion.
+
+The `String#replaceAll()` call takes a regular expression for the first argument, which is then compiled and used to replace string subsections. However, the argument being passed to it doesn't actually appear to be a regular expression. Therefore, the `replace()` [API](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#replace-java.lang.CharSequence-java.lang.CharSequence-) appears to be a better fit.
+
+Our changes look something like this:
+
+```diff
+    String init = "my string\n";
+
+-   String changed = init.replaceAll("\n", "<br>");
++   String changed = init.replace("\n", "<br>");
+```
+
+If you have feedback on this codemod, [please let us know](mailto:feedback@pixee.ai)!
+
+## F.A.Q.
+
+### Why is this codemod marked as Merge After Cursory Review?
+
+There should be no functional changes after this change, but this depends on Sonar's accuracy Sonar in assessing whether the first argument contains regex metacharacters. Our testing shows this is a safe assumption, but the behavior can't be guaranteed. 
+
+## Codemod Settings
+
+N/A
+
+## References
+
+* [https://rules.sonarsource.com/java/RSPEC-5361/](https://rules.sonarsource.com/java/RSPEC-5361/)

--- a/docs/codemods/python/pixee_python_bad-lock-with-statement.md
+++ b/docs/codemods/python/pixee_python_bad-lock-with-statement.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/bad-lock-with-statement
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Low       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | No                     |
 
 This codemod separates creating a threading lock instance from calling it as a context manager. Calling `with threading.Lock()` does not have the effect you would expect. The lock is not acquired. Instead, to correctly acquire a lock, create the instance separately, before calling it as a context manager.
 

--- a/docs/codemods/python/pixee_python_django-debug-flag-on.md
+++ b/docs/codemods/python/pixee_python_django-debug-flag-on.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/django-debug-flag-on
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Medium     | Merge After Cursory Review | No                     |
 
 This codemod will flip django's `DEBUG` flag to `False` if it's `True` on the `settings.py` file within django's default directory structure.
 

--- a/docs/codemods/python/pixee_python_django-json-response-type.md
+++ b/docs/codemods/python/pixee_python_django-json-response-type.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/django-json-response-type
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | No                     |
 
 The default `content_type` for `HttpResponse` in Django is `'text/html'`. This is true even when the response contains JSON data.
 If the JSON contains (unsanitized) user-supplied input, a malicious user may supply HTML code which leaves the application vulnerable to cross-site scripting (XSS). 

--- a/docs/codemods/python/pixee_python_django-receiver-on-top.md
+++ b/docs/codemods/python/pixee_python_django-receiver-on-top.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/django-receiver-on-top
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | No                     |
 
 Django uses signals to notify and handle actions that happens elsewhere in the application. You can define a response to a given signal by decorating a function with the `@receiver(signal)` decorator. The order in which the decorators are declared for this function is important. If the `@receiver` decorator is not on top, any decorators before it will be ignored. 
 Our changes look something like this:

--- a/docs/codemods/python/pixee_python_django-session-cookie-secure-off.md
+++ b/docs/codemods/python/pixee_python_django-session-cookie-secure-off.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/django-session-cookie-secure-off
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Medium     | Merge After Cursory Review | No                     |
 
 This codemod will set django's `SESSION_COOKIE_SECURE` flag to `True` if it's `False` or missing on the `settings.py` file within django's default directory structure.
 

--- a/docs/codemods/python/pixee_python_enable-jinja2-autoescape.md
+++ b/docs/codemods/python/pixee_python_enable-jinja2-autoescape.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/enable-jinja2-autoescape
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| High       | Merge Without Review | No                     |
 
 This codemod enables autoescaping of HTML content in `jinja2`. Unfortunately, the jinja2 default behavior is to not autoescape when rendering templates, which makes your applications potentially vulnerable to Cross-Site Scripting (XSS) attacks.
 

--- a/docs/codemods/python/pixee_python_fix-deprecated-abstractproperty.md
+++ b/docs/codemods/python/pixee_python_fix-deprecated-abstractproperty.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/fix-deprecated-abstractproperty
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Low       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | No                     |
 
 The `@abstractproperty` decorator from `abc` has been [deprecated](https://docs.python.org/3/library/abc.html#abc.abstractproperty) since Python 3.3. This is because it's possible to use `@property` in combination with `@abstractmethod`. 
 

--- a/docs/codemods/python/pixee_python_fix-file-resource-leak.md
+++ b/docs/codemods/python/pixee_python_fix-file-resource-leak.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/fix-file-resource-leak
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| High       | Merge Without Review | No                     |
 
 This codemod wraps assignments of `open` calls in a with statement. Without explicit closing, these resources will be "leaked" and won't be re-claimed until garbage collection. In situations where these resources are leaked rapidly (either through malicious repetitive action or unusually spiky usage), connection pool or file handle exhaustion will occur. These types of failures tend to be catastrophic, resulting in downtime and many times affect downstream applications.
 

--- a/docs/codemods/python/pixee_python_fix-mutable-params.md
+++ b/docs/codemods/python/pixee_python_fix-mutable-params.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/fix-mutable-params
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | No                     |
 
 Using mutable values for default arguments is not a safe practice.
 Look at the following very simple example code:

--- a/docs/codemods/python/pixee_python_flask-json-response-type.md
+++ b/docs/codemods/python/pixee_python_flask-json-response-type.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/flask-json-response-type
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | No                     |
 
 The default `mimetype` for `make_response` in Flask is `'text/html'`. This is true even when the response contains JSON data.
 If the JSON contains (unsanitized) user-supplied input, a malicious user may supply HTML code which leaves the application vulnerable to cross-site scripting (XSS). 

--- a/docs/codemods/python/pixee_python_harden-pyyaml.md
+++ b/docs/codemods/python/pixee_python_harden-pyyaml.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/harden-pyyaml
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | No                     |
 
 This codemod hardens all [`yaml.load()`](https://pyyaml.org/wiki/PyYAMLDocumentation) calls against attacks that could result from deserializing untrusted data.
 

--- a/docs/codemods/python/pixee_python_harden-ruamel.md
+++ b/docs/codemods/python/pixee_python_harden-ruamel.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/harden-ruamel
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | No                     |
 
 This codemod hardens any unsafe [`ruamel.yaml.YAML()`](https://yaml.readthedocs.io/en/latest/) calls against attacks that could result from deserializing untrusted data.
 

--- a/docs/codemods/python/pixee_python_https-connection.md
+++ b/docs/codemods/python/pixee_python_https-connection.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/https-connection
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| High       | Merge Without Review | No                     |
 
 This codemod replaces calls to `urllib3.connectionpool.HTTPConnectionPool` and `urllib3.HTTPConnectionPool` with their secure variant (`HTTPSConnectionPool`).
 

--- a/docs/codemods/python/pixee_python_jwt-decode-verify.md
+++ b/docs/codemods/python/pixee_python_jwt-decode-verify.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/jwt-decode-verify
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| High       | Merge Without Review | No                     |
 
 This codemod ensures calls to [jwt.decode](https://pyjwt.readthedocs.io/en/stable/api.html#jwt.decode) do not disable signature validation and other verifications. It checks that both the `verify` parameter (soon to be deprecated) and any `verify` key in the `options` dict parameter are not assigned to `False`.
 

--- a/docs/codemods/python/pixee_python_limit-readline.md
+++ b/docs/codemods/python/pixee_python_limit-readline.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/limit-readline
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Medium     | Merge After Cursory Review | No                     |
 
 This codemod hardens all [`readline()`](https://docs.python.org/3/library/io.html#io.IOBase.readline) calls from file objects returned from an `open()` call, `StringIO` and `BytesIO` against denial of service attacks. A stream influenced by an attacker could keep providing bytes until the system runs out of memory, causing a crash.
 

--- a/docs/codemods/python/pixee_python_numpy-nan-equality.md
+++ b/docs/codemods/python/pixee_python_numpy-nan-equality.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/numpy-nan-equality
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Medium     | Merge Without Review | No                     |
 
 Comparisons against `numpy.nan` always result in `False`. Thus comparing an expression directly against `numpy.nan` is always unintended. The correct way to compare a value for `NaN` is to use the `numpy.isnan` function.
 

--- a/docs/codemods/python/pixee_python_remove-unnecessary-f-str.md
+++ b/docs/codemods/python/pixee_python_remove-unnecessary-f-str.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/remove-unnecessary-f-str
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Low       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | No                     |
 
 This codemod converts any f-strings without interpolated variables into regular strings.
 In these cases the use of f-string is not necessary; a simple string literal is sufficient. 

--- a/docs/codemods/python/pixee_python_requests-verify.md
+++ b/docs/codemods/python/pixee_python_requests-verify.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/requests-verify
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| High       | Merge After Cursory Review | No                     |
 
 This codemod checks that calls to the `requests` module API use `verify=True` or a path to a CA bundle to ensure TLS certificate validation.
 

--- a/docs/codemods/python/pixee_python_safe-lxml-parser-defaults.md
+++ b/docs/codemods/python/pixee_python_safe-lxml-parser-defaults.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/safe-lxml-parser-defaults
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| High       | Merge Without Review | No                     |
 
 This codemod configures safe parameter values when initializing `lxml.etree.XMLParser`, `lxml.etree.ETCompatXMLParser`, `lxml.etree.XMLTreeBuilder`, or `lxml.etree.XMLPullParser`. If parameters `resolve_entities`, `no_network`, and `dtd_validation` are not set to safe values, your code may be vulnerable to entity expansion attacks and external entity (XXE) attacks.
 

--- a/docs/codemods/python/pixee_python_safe-lxml-parsing.md
+++ b/docs/codemods/python/pixee_python_safe-lxml-parsing.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/safe-lxml-parsing
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| High       | Merge Without Review | No                     |
 
 This codemod sets the `parser` parameter in calls to  `lxml.etree.parse`  and `lxml.etree.fromstring` if omitted or set to `None` (the default value). Unfortunately, the default `parser=None` means `lxml` will rely on an unsafe parser, making your code potentially vulnerable to entity expansion attacks and external entity (XXE) attacks.
 

--- a/docs/codemods/python/pixee_python_sandbox-process-creation.md
+++ b/docs/codemods/python/pixee_python_sandbox-process-creation.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/sandbox-process-creation
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| High       | Merge After Cursory Review | No                     |
 
 This codemod sandboxes all instances of [subprocess.run](https://docs.python.org/3/library/subprocess.html#subprocess.run) and [subprocess.call](https://docs.python.org/3/library/subprocess.html#subprocess.call) to offer protection against attack.
 

--- a/docs/codemods/python/pixee_python_secure-flask-cookie.md
+++ b/docs/codemods/python/pixee_python_secure-flask-cookie.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/secure-flask-cookie
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Medium     | Merge After Cursory Review | No                     |
 
 This codemod sets the most secure parameters when Flask applications call `set_cookie` on a response object. Without these parameters, your Flask
 application cookies may be vulnerable to being intercepted and used to gain access to sensitive data.

--- a/docs/codemods/python/pixee_python_secure-flask-session-configuration.md
+++ b/docs/codemods/python/pixee_python_secure-flask-session-configuration.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/secure-flask-session-configuration
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Medium       | Merge After Review | No                  |
+| Importance | Review Guidance    | Requires Scanning Tool |
+|------------|--------------------|------------------------|
+| Medium     | Merge After Review | No                     |
 
 Flask applications can configure sessions behavior at the application level. 
 This codemod looks for Flask application configuration that set `SESSION_COOKIE_HTTPONLY`, `SESSION_COOKIE_SECURE`, or `SESSION_COOKIE_SAMESITE` to an insecure value and changes it to a secure one.

--- a/docs/codemods/python/pixee_python_secure-random.md
+++ b/docs/codemods/python/pixee_python_secure-random.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/secure-random
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| High       | Merge After Cursory Review | No                     |
 
 This codemod replaces all instances of functions in the `random` module (e.g. `random.random()` with their, much more secure, equivalents from the `secrets` module (e.g. `secrets.SystemRandom().random()`).
 

--- a/docs/codemods/python/pixee_python_secure-tempfile.md
+++ b/docs/codemods/python/pixee_python_secure-tempfile.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/secure-tempfile
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| High       | Merge Without Review | No                     |
 
 This codemod replaces all `tempfile.mktemp` calls to the more secure `tempfile.mkstemp`.
 

--- a/docs/codemods/python/pixee_python_sql-parameterization.md
+++ b/docs/codemods/python/pixee_python_sql-parameterization.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/sql-parameterization
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| High       | Merge After Cursory Review | No                     |
 
 This codemod refactors SQL statements to be parameterized, rather than built by hand.
 

--- a/docs/codemods/python/pixee_python_upgrade-sslcontext-minimum-version.md
+++ b/docs/codemods/python/pixee_python_upgrade-sslcontext-minimum-version.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/upgrade-sslcontext-minimum-version
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| High       | Merge Without Review | No                     |
 
 This codemod replaces all unsafe and/or deprecated SSL/TLS versions when used
 to set the `ssl.SSLContext.minimum_version` attribute. It uses

--- a/docs/codemods/python/pixee_python_upgrade-sslcontext-tls.md
+++ b/docs/codemods/python/pixee_python_upgrade-sslcontext-tls.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/upgrade-sslcontext-tls
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| High       | Merge After Cursory Review | No                     |
 
 This codemod replaces the use of all unsafe and/or deprecated SSL/TLS versions
 in the `ssl.SSLContext` constructor. It uses `PROTOCOL_TLS_CLIENT` instead,

--- a/docs/codemods/python/pixee_python_url-sandbox.md
+++ b/docs/codemods/python/pixee_python_url-sandbox.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/url-sandbox
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| High       | Merge After Cursory Review | No                     |
 
 This codemod sandboxes calls to [`requests.get`](https://requests.readthedocs.io/en/latest/api/#requests.get) to be more resistant to Server-Side Request Forgery (SSRF) attacks.
 

--- a/docs/codemods/python/pixee_python_use-defusedxml.md
+++ b/docs/codemods/python/pixee_python_use-defusedxml.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/use-defusedxml
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| High       | Merge After Review | No                  |
+| Importance | Review Guidance    | Requires Scanning Tool |
+|------------|--------------------|------------------------|
+| High       | Merge After Review | No                     |
 
 You might be surprised to learn that Python's built-in XML libraries are [considered insecure](https://docs.python.org/3/library/xml.html#xml-vulnerabilities) against various kinds of attacks.
 

--- a/docs/codemods/python/pixee_python_use-generator.md
+++ b/docs/codemods/python/pixee_python_use-generator.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/use-generator
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Low       | Merge Without Review | No                  |
+| Importance | Review Guidance      | Requires Scanning Tool |
+|------------|----------------------|------------------------|
+| Low        | Merge Without Review | No                     |
 
 Imagine that someone handed you a pile of 100 apples and then asked you to count how many of them were green without putting any of them down. You'd probably find this quite challenging and you'd struggle to hold the pile of apples at all. Now imagine someone handed you the apples one at a time and asked you to just count the green ones. This would be a much easier task.
 

--- a/docs/codemods/python/pixee_python_use-walrus-if.md
+++ b/docs/codemods/python/pixee_python_use-walrus-if.md
@@ -5,9 +5,9 @@ sidebar_position: 1
 
 ## pixee:python/use-walrus-if
 
-| Importance | Review Guidance            | Requires SARIF Tool |
-|------------|----------------------------|---------------------|
-| Low       | Merge After Cursory Review | No                  |
+| Importance | Review Guidance            | Requires Scanning Tool |
+|------------|----------------------------|------------------------|
+| Low        | Merge After Cursory Review | No                     |
 
 This codemod updates places where two separate statements involving an assignment and conditional can be replaced with a single Assignment Expression (commonly known as the walrus operator).
 


### PR DESCRIPTION
Incidentally, cleaned up the markdown for all the tables in the `python` folder and changed all instances of "Requires SARIF Tool" to "Requires Scanning Tool".