### PR TITLE
Update canonical URL

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Pixee',
-  tagline: 'Elevate your code, one automated commit at a time.', //TODO: We need a tag line!
+  tagline: 'Pixee is your automated product security engineer', //TODO: We need a tag line!
   url: 'https://docs.pixee.ai',
   baseUrl: '/',
   onBrokenLinks: 'throw',


### PR DESCRIPTION
This will prevent a 404 when someone goes to `docs.pixee.ai//`.