### PR TITLE
Set deep links

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,20 +17,20 @@ We're working hard to bring you new features, enhancements, and reliability to t
 >
 > The dashboard is automatically enabled upon installation, provided that GitHub Issues are also enabled for your repository. See Activity dashboard documentation [here](https://docs.pixee.ai/using-pixeebot/#pixeebot-activity).
 
-### Pixeebot App + Platform
+### Pixeebot App + Platform {#2024-01-26---pixeebot-app--platform}
 
 #### 🚀 New Features & Enhancements {#2024-01-26---new-features--enhancements}
 
 * Released performance improvement for navigating between pages on the user dashboard.
 
-#### 🐛 Bug Fixes
+#### 🐛 Bug Fixes {#2024-01-26---bug-fixes}
 
 * Resolved a bug that occurred when users requested a continuous improvement changes using `@pixeebot next`, Pixeebot would analyze the user’s repository twice and potentially send two PRs.
   
 
-### Codemodder
+### Codemodder {#2024-01-26---codemodder}
 
-#### 🐍 Python
+#### 🐍 Python {#2024-01-26---codemodder-python}
 
 * `security` package updates and release
 * New codemod: `combine-startswith-endswith` Simplifies boolean expressions used with the `startswith` and `endswith` methods of `str` objects. A lot of code uses boolean expressions such as `x.startswith('foo')` or `x.startswith('bar')` , which is unnecessary since these objects can accept a tuple of strings to match. Where possible, this codemod replaces such boolean expressions with `x.startswith(('foo', 'bar))` for cleaner, more concise code. See codemod documentation [here](https://docs.pixee.ai/codemods/python/pixee_python_combine-startswith-endswith) 
@@ -40,7 +40,7 @@ We're working hard to bring you new features, enhancements, and reliability to t
 * New codemod: `replace-flask-send-fil`e Introduces protections against path traversal attacks when using the `Flask` `send_file` function. This codemod uses Flasks’s `flask.send_from_directory` function for input path validation. See codemod documentation [here](https://docs.pixee.ai/codemods/python/pixee_python_replace-flask-send-file)
 * New codemod: `use-set-literal` Converts Python set constructions using literal list arguments into more efficient and readable set literals. It simplifies expressions like `set([1, 2, 3])` to `{1, 2, 3}`, enhancing both performance and code clarity. See codemod documentation [here](https://docs.pixee.ai/codemods/python/pixee_python_use-set-literal#pixeepythonuse-set-literal)
 
- #### ☕️ Java
+ #### ☕️ Java {#2024-01-26---codemodder-java}
  * Added short-circuiting to improve performance of composed codemods
  * New codemod: `sonar:java/remove-unused-private-method` removes unused `private` methods. These can increase both the mental load and maintenance burden of maintainers, as you have to keep compiling the unused code when making sweeping changes to the APIs used within the method. (for Sonar) See codemod documentation [here](https://docs.pixee.ai/codemods/java/sonar_java_remove-unused-private-method-s1144)
  * New codemod: `sonar:java/declare-variable-on-separate-line` splits variable assignments onto their own lines. [Many](https://wiki.sei.cmu.edu/confluence/display/java/DCL52-J.+Do+not+declare+more+than+one+variable+per+declaration) [sources](https://rules.sonarsource.com/java/RSPEC-1659/) [believe](https://dart.dev/tools/linter-rules/avoid_multiple_declarations_per_line) it is easier to review code where the variables are separate statements on their own individual line. (for Sonar) See codemod documentation [here](https://docs.pixee.ai/codemods/java/sonar_java_declare-variable-on-separate-line-s1659) 
@@ -55,7 +55,7 @@ We're working hard to bring you new features, enhancements, and reliability to t
 > You can now access Pixee’s automated code hardening functionalities from the command line! The Pixee CLI gives you the ability to run Java and Python codemods and apply recommended code changes locally, in your own development environment.
 > We built this to give developers the ability to see and apply the types of changes Pixee recommends, before installing Pixeebot on their GitHub repositories. **See Pixee CLI documentation [here](https://www.pixee.ai/cli)**
 
-### Pixeebot App + Platform
+### Pixeebot App + Platform {#2023-12-29---pixeebot-app--platform}
 
 #### 🚀 New Features & Enhancements {#2023-12-29---new-features--enhancements}
 
@@ -63,14 +63,14 @@ We're working hard to bring you new features, enhancements, and reliability to t
 - Styling updates to the user platform, including skeleton tables for loading and improvements to color consistency
 - Enhancement to improve load time performance on the installations page
 
-#### 🐛 Bug Fixes
+#### 🐛 Bug Fixes {#2023-12-29---bug-fixes}
 
 - Fixed bugs related to activation and commit status data to ensure both statuses are displayed correctly on the user platform
 - Resolved a bug that caused duplicate pull requests to be opened for Pixeebot recommendations
 
-### Codemodder
+### Codemodder {#2023-12-29---codemodder}
 
-#### 🐍 Python
+#### 🐍 Python {#2023-12-29---codemodder-python}
 
 - New codemod: `add-requests-timeout` adds a timeout to requests made using the requests package. These requests do not timeout by default, which is potentially unsafe as it can cause an application to hang indefinitely. See codemod documentation [here](https://docs.pixee.ai/codemods/python/pixee_python_add-requests-timeouts)
 - New codemod: `remove-future-imports` removes all `__future__` imports often found in older codebases for forward compatibility with features. While harmless, they are also unnecessary. And in most cases, you probably just forgot to remove them. See codemod documentation [here](https://docs.pixee.ai/codemods/python/pixee_python_remove-future-imports)
@@ -78,7 +78,7 @@ We're working hard to bring you new features, enhancements, and reliability to t
 - New codemod: `exception-without-raise` fixes cases where an exception is referenced by itself in a statement without being raised. This most likely indicates a bug: you probably meant to actually raise the exception. See codemod documentation [here](https://docs.pixee.ai/codemods/python/pixee_python_exception-without-raise)
 - Enhanced pull request descriptions for Python codemods that add new dependencies. When a codemod fails to add a dependency, these enhancements provide additional context as to why
 
-#### ☕️ Java
+#### ☕️ Java {#2023-12-29---codemodder-java}
 
 - New codemod: `sonar:java/remove-commented-code` eliminates commented-out code that may impede readability and distract focus. (for Sonar) See codemod documentation [here](https://docs.pixee.ai/codemods/java/sonar_java_remove-commented-code-s125)
 - New codemod: `sonar:java/replace-stream-collectors-to-list` modernizes a stream's `List` creation to be driven from the simple, and more readable [`Stream#toList()`](<https://docs.oracle.com/javase/16/docs/api/java.base/java/util/stream/Collectors.html#toList()>) method. (for Sonar) See codemod documentation [here](https://docs.pixee.ai/codemods/java/sonar_java_replace-stream-collectors-to-list-s6204)
@@ -93,21 +93,21 @@ This entry covers updates and enhancements implemented in October and November. 
 > **Updated Pixeebot app permissions:**
 > To give users feedback in real time about Pixeebot Analysis, we have requested additional Github Application Permissions. **This change increases Pixeebot's access to Checks from read-only to read and write.** Existing users must update their app permissions and have received an email prompting them to do so. Please reach out to us with any questions!
 
-### Pixeebot App + Platform
+### Pixeebot App + Platform {#2023-12-12---pixeebot-app--platform}
 
-#### 🚀 New Features & Enhancements
+#### 🚀 New Features & Enhancements {#2023-12-12---new-features--enhancements}
 
 - Enhanced first-time user modal and replaced with welcome toast
 - Improved consistency in dashboard with styling updates and modifications
 - Improved reliability of Codemod orchestration platform
 
-#### 🐛 Bug Fixes
+#### 🐛 Bug Fixes {#2023-12-12---bug-fixes}
 
 - Addressed intermittent issues with authentication tokens invalidating user sessions
 
-### Codemodder
+### Codemodder {#2023-12-12---codemodder}
 
-#### 🐍 Python
+#### 🐍 Python {#2023-12-12---codemodder-python}
 
 General support for Python is live! Some updates that made Python support possible:
 
@@ -121,7 +121,7 @@ General support for Python is live! Some updates that made Python support possib
   - Integrating a `setup.py` writer functionality
   - Enabling the Python repo manager with a basic heuristic for dependency location selection
 
-#### ☕️ Java
+#### ☕️ Java {#2023-12-12---codemodder-java}
 
 - New codemod: used for setting a private constructor to hide implicit public constructor (for Sonar)
 - New codemod: replaces `@Controller` with `@RestController` and removes `@ResponseBody` annotations (for Sonar)
@@ -132,54 +132,54 @@ General support for Python is live! Some updates that made Python support possib
 
 ## October 13, 2023
 
-#### 🚀 New Features & Enhancements
+#### 🚀 New Features & Enhancements {#2023-10-13---new-features--enhancements}
 
 - More Python codemods are out! 15+ and counting...
 - Python now supports PR Hardening mode
 
-#### 🐛 Bug Fixes
+#### 🐛 Bug Fixes {#2023-10-13---bug-fixes}
 
 - Temporary fix for repository enrollment issues
 
 ## October 6, 2023
 
-#### 🚀 New Features & Enhancements
+#### 🚀 New Features & Enhancements {#2023-10-06---new-features--enhancements}
 
 - 🐍Python Alpha: Python support is here! All repos will be waitlisted automatically, but if you’d like to give it a try, use a fork or clone of Pygoat
 - Light Mode: We heard you. Introducing a sleek Light Mode
 - Java Security Toolkit now supports Java modules
 
-#### 🐛 Bug Fixes
+#### 🐛 Bug Fixes {#2023-10-06---bug-fixes}
 
 - `pom.xml` Formatting: Fixed formatting issues
 - `@pixeebot next` behavior: Fixed occurrences where this option was being shown erroneously or duplicating PRs
 
 ## September 29, 2023
 
-#### 🚀 New Features & Enhancements
+#### 🚀 New Features & Enhancements {#2023-09-29---new-features--enhancements}
 
 - ✨AI PR Comments are here: We're excited to announce that AI enrichment of Pixeebot PRs is now live! This powerful feature enhances your PRs with insights & comments that are specific to your code. Goodbye uninspiring comments
 - Codemodder Orchestrator: We’re ready to scale! The underlying infrastructure has been completely revamped to improve scalability, performance, reliability, and security
 - Java is Generally Available! Your Java repos will no longer be waitlisted
 
-#### 🐛 Bug Fixes
-
+#### 🐛 Bug Fixes {#2023-09-29---bug-fixes}
+ 
 - GitHub Comment Errors: We've resolved the issue where 422 errors were encountered while leaving comments on GitHub. You can now interact seamlessly without errors
 
 ## September 22, 2023
 
-#### 🚀 New Features & Enhancements
+#### 🚀 New Features & Enhancements {#2023-09-22---new-features--enhancements}
 
 - Added some examples to `codemodder-java` project for more examples of the types of codemods one can make
 - We found a CVE in Node.js! Read about it here: https://blog.pixee.ai/breaking-down-the-nodejs-sandbox-bypass-cve-2023-30587
 
-#### 🐛 Bug Fixes
+#### 🐛 Bug Fixes {#2023-09-22---bug-fixes}
 
 - Various bug fixes
 
 ## September 15, 2023
 
-#### 🚀 New Features & Enhancements
+#### 🚀 New Features & Enhancements {#2023-09-15---new-features--enhancements}
 
 - Improved platform reliability with better reporting and cloud configuration
 - Various performance improvements
@@ -187,24 +187,24 @@ General support for Python is live! Some updates that made Python support possib
 
 ## September 8, 2023
 
-#### 🚀 New Features & Enhancements
+#### 🚀 New Features & Enhancements {#2023-09-08---new-features--enhancements}
 
 - Message Updates for Pixeebot: Smarter choices when there are no PR enhancements, plus clearer messaging. Enjoy
 - Various performance improvements
 
-#### 🐛 Bug Fixes
+#### 🐛 Bug Fixes {#2023-09-08---bug-fixes}
 
 - Various stability improvements
 
 ## September 1, 2023
 
-#### 🚀 New Features & Enhancements
+#### 🚀 New Features & Enhancements {#2023-09-01---new-features--enhancements}
 
 - User Dashboard Upgrade: New look, feel, and onboarding experience for Pixeebot users
 - Accelerated Waitlist: We’re letting more Java repositories in. If your Java repo is still waitlisted, please be patient; it’ll get in soon!
 - Various performance improvements
 
-#### 🐛 Bug Fixes
+#### 🐛 Bug Fixes {#2023-09-01---bug-fixes}
 
 - Codemodder-java: A bug preventing files outside of src/main/java from being hardened has been resolved
 - Docs page for SQL parameterization codemod has been updated to eliminate any confusion


### PR DESCRIPTION
Explicitly set the deep link to each section based on release note entry date  per https://docusaurus.io/docs/2.x/markdown-features/toc#heading-ids