### PR TITLE
fix hyperlinks to tool pages & Contrast page title

### DIFF
--- a/docs/code-scanning-tools/contrast.md
+++ b/docs/code-scanning-tools/contrast.md
@@ -1,9 +1,9 @@
 ---
-title: "Contrast (IAST)"
+title: "Contrast Security (IAST)"
 sidebar_position: 4
 ---
 
-# Snyk Code
+# Contrast Security Assess (IAST)
 
 Pixee can automatically fix and triage issues detected by [Contrast Assess (IAST)](https://contrastsecurity.com/).
 

--- a/docs/code-scanning-tools/overview.md
+++ b/docs/code-scanning-tools/overview.md
@@ -12,8 +12,8 @@ Pixee automatically triages and fixes issues detected by code scanning tools whe
 - [Semgrep](/code-scanning-tools/semgrep)
 - [CodeQL](/code-scanning-tools/codeql)
 - [Snyk](/code-scanning-tools/snyk)
-- [Contrast Security](/code-scanning-tools/codeql)
-- [HCL AppScan](/code-scanning-tools/codeql)
+- [Contrast Security](/code-scanning-tools/contrast)
+- HCL AppScan
 - Checkmarx (beta)
 
 # Supported Rules


### PR DESCRIPTION
fix wrong hyperlinks to contrast + HCL. Removed hyperlink for HCL for now until a page is published.