### PR TITLE
Update Code Scanner support docs overview

### DIFF
--- a/docs/code-scanning-tools/overview.md
+++ b/docs/code-scanning-tools/overview.md
@@ -15,6 +15,9 @@ Pixee automatically triages and fixes issues detected by code scanning tools whe
 - [Contrast Security](/code-scanning-tools/contrast)
 - HCL AppScan
 - Checkmarx
+- GitLab SAST
+- Veracode
+- Coverity on Polaris
 
 # Supported Rules
 


### PR DESCRIPTION
Updated Code Scanner support docs page to add the following supported scanners:

- GitLab SAST
- Veracode 
- Coverity on Polaris