### PR TITLE
Enable Renovate auto-merge

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,6 +2,7 @@ name: PR Checks
 
 on:
   pull_request:
+  merge_group:
 
 jobs:
   pr-checks:

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,8 @@
   "prHourlyLimit": 2,
   "prConcurrentLimit": 3,
   "timezone": "America/New_York",
-  "schedule": ["before 8am every weekday"]
+  "schedule": ["before 8am every weekday"],
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true
 }


### PR DESCRIPTION
## Summary
- Enables auto-merge for Renovate PRs (`automerge`, `automergeType: "pr"`, `platformAutomerge`)
- Reduces manual toil for dependency updates

## Test plan
- [ ] Verify Renovate picks up the new config on next run
- [ ] Confirm next Renovate PR is auto-merged after checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)