### PR TITLE
Set Renovate rangeStrategy to bump

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":dependencyDashboard"],
+  "rangeStrategy": "bump",
   "prHourlyLimit": 2,
   "prConcurrentLimit": 3,
   "timezone": "America/New_York",


### PR DESCRIPTION
## Problem

Renovate has been opening dependency PRs that **break the build**. The default `rangeStrategy` (`"auto"`, via `config:recommended`) leaves `package.json` version ranges untouched whenever the new version is still within the existing range — it only updates the lockfiles. But it rewrote the lockfile entries to new specs (e.g. `prettier@^3.8.4`, `react@^19.2.7`) that **no longer matched** the `package.json` constraints (`^3.2.5`, `^19.0.0`).

The result: `yarn install --frozen-lockfile` (in the `test-deploy` CI job) couldn't find a lockfile entry matching the declared constraint and failed → build broken. This bit #257 (prettier) and #251 (react monorepo), each of which had to be fixed by hand.

## Fix

Set `"rangeStrategy": "bump"`. Renovate now bumps the `package.json` range to the new version **and** regenerates the lockfiles together, keeping the manifest and lockfiles consistent — the same thing we were doing manually.

## Note (follow-up, not in this PR)

The repo carries **both** `yarn.lock` and `package-lock.json`; CI only uses yarn. The redundant `package-lock.json` is extra surface for these desyncs. Worth removing in a separate change so only one lockfile is maintained.