### PR TITLE
Migrate onBrokenMarkdownLinks to markdown.hooks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,8 +11,12 @@ const config = {
   url: "https://docs.pixee.ai",
   baseUrl: "/",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
   favicon: "img/favicon.ico",
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "warn",
+    },
+  },
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
## What

Moves the `onBrokenMarkdownLinks: "warn"` setting from the top-level `siteConfig` into `siteConfig.markdown.hooks.onBrokenMarkdownLinks`.

## Why

Docusaurus emits this deprecation warning on build:

> [WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4. Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.

This change clears the warning and keeps us compatible with Docusaurus v4. Behavior is unchanged — broken markdown links still emit a warning.

## Testing

- `yarn build` completes successfully (Node 24.18.0) with no `onBrokenMarkdownLinks` deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)